### PR TITLE
Add whitelist of files to be published on npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
   "main": "./lib/runner.js",
   "scripts": {
     "test": "make ci"
-  }
+  },
+  "files": [
+    "lib"
+  ]
 }


### PR DESCRIPTION
This reduces the size of the package from 7.8 kB (22.6 kB unpacked) to 5.4 kB (14.5 kB unpacked).