### PR TITLE
Force project to use v2.4 of HTML_CodeSniffer

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
     "test": "make ci"
   },
   "dependencies": {
-    "html_codesniffer": "^2.4.1"
+    "html_codesniffer": "~2.4.1"
   }
 }


### PR DESCRIPTION
A side-effect of NPM using the `package-lock.json` file is that this file is _not_ published with an NPM package, which means that, when NPM tries to resolve dependencies on an npm install it will happily install newer versions of dependencies as long as they fulfil whatever conditions specified in the `package.json` file (not the lockfile).

For example,

* `pa11y@5.3.0`:
  * requires `pa11y-runner-htmlcs@^1.2.0` in its `package.json`
  * has `pa11y-runner-htmlcs@1.2.0` in its `package-lock.json`
* `pa11y-runner-htmlcs@1.2.0`:
  * requires `html_codesniffer@^2.4.1` in its `package.json`
  * has `html_codesniffer@2.4.1` in its `package-lock.json`

Running:

```sh
npm install --global pa11y@5.3.0
```

...will result in the installation of `pa11y@5.3.0`, which will pull `pa11y-runner-htmlcs@1.2.0` (intended, although by accident) and `html_codesniffer@2.5.1` (unintended). HTML_CS 2.5 contains new WCAG 2.1 rules that we've decided to keep for pa11y v6 as to try to ensure that we don't break people's workflows.

This PR replaces `^` with `~` in the package.json, pinning htmlcs to version 2.4.x.